### PR TITLE
Add basic support for copying cells and rows

### DIFF
--- a/web/src/Table.tsx
+++ b/web/src/Table.tsx
@@ -8,7 +8,7 @@ import { TableSettings } from './TableControls'
 import { AttributeMap, DataHeader, DataHeaders } from './query-results'
 import { parseByInferredType } from './utils'
 
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 export interface TableProps {
   content: AttributeMap[]
   headers: DataHeaders
@@ -20,6 +20,7 @@ const paginationPageSizeSelector = [10, 20, 50, 100, 200, 500, 1000]
 export function Table({ content, headers, settings }: TableProps) {
   const columns = headers.map((header: DataHeader) => ({
     field: header.name,
+    editable: true,
   }))
 
   const data = useMemo(() => {
@@ -37,6 +38,58 @@ export function Table({ content, headers, settings }: TableProps) {
     )
   }, [content, headers])
 
+  const grid = useRef<AgGridReactType>(null)
+
+  const copyAllRowsToClipboard = _ => {
+    grid.current.api.selectAll()
+    copySelectedRowsToClipboard()
+  }
+
+  const copySelectedRowsToClipboard = _ => {
+    const copyFormat = document.getElementById('copyformat').value
+    const copyHeaders = document.getElementById('copyheaders').checked
+    const rows = grid.current.api.getSelectedRows()
+
+    const columnNames = grid.current.api.getAllDisplayedColumns()
+      .map(x => x.colId)
+
+    if (copyHeaders && copyFormat !== 'json') {
+      let row = {}
+      for (const name of columnNames) {
+        row[name] = name
+      }
+      rows.unshift(row)
+    }
+
+    let text = ''
+    switch (copyFormat) {
+      case 'html':
+        text = buildTableHtml(columnNames, rows)
+        break
+      case 'csv':
+        text = formatCsv(columnNames, rows)
+        break
+      case 'tab':
+        text = formatTabSeparated(columnNames, rows)
+        break
+      case 'json':
+        text = JSON.stringify(rows)
+        break
+    }
+
+    const span = document.createElement('span')
+    span.style.cssText = 'position:fixed;left:0;top:0;opacity:0;'
+    span.innerHTML = text
+    document.body.appendChild(span)
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(span)
+    selection.removeAllRanges()
+    selection.addRange(range)
+    document.execCommand('copy')
+    document.body.removeChild(span)
+  }
+  
   return (
     <div
       style={{
@@ -48,13 +101,51 @@ export function Table({ content, headers, settings }: TableProps) {
         style={{ height: `${settings.gridCellHeightPx}px` }} // the grid will fill the size of the parent container
       >
         <AgGridReact
+          ref={grid}
           rowData={data}
+          rowSelection={'multiple'}
           columnDefs={columns}
           pagination={true}
           paginationPageSize={paginationPageSize}
           paginationPageSizeSelector={paginationPageSizeSelector}
         />
       </div>
+
+      <button onClick={_ => copySelectedRowsToClipboard()}>Copy Selected Rows</button>
+      <button onClick={_ => copyAllRowsToClipboard()}>Copy All Rows</button>
+      <select id="copyformat">
+        <option value="html">HTML Table</option>
+        <option value="csv">CSV</option>
+        <option value="tab">Tab Separated</option>
+        <option value="json">JSON</option>
+      </select>
+      <label>
+        <input type="checkbox" id="copyheaders" defaultChecked />
+        Copy header values
+      </label>
     </div>
   )
+}
+
+const buildTableHtml = (columnNames, rows) => {
+  return '<table>' + rows
+    .map(x => '<tr>' + columnNames.map(y => `<td>${x[y]}</td>`).join('') + '</tr>').join('')
+    + '</table>'
+}
+
+const formatTabSeparated = (columnNames, rows) => {
+  return '<pre>' + rows
+    //.map(x => Object.keys(x).map(y => x[y]))
+    .map(x => columnNames.map(y => x[y]))
+    .map(x => x.join('\t'))
+    .join('\n')
+    + '</pre>'
+}
+
+const formatCsv = (columnNames, rows) => {
+  return '<pre>' + rows
+    .map(x => columnNames.map(y => `"${x[y.replace('"', '\"')]}"`))
+    .map(x => x.join(','))
+    .join('\n')
+    + '</pre>'
 }


### PR DESCRIPTION
This plugin is wonderful!

It would be great to be able to highlight and copy/paste the output from the AgGrid to other programs.
It looks like the fancy cell highlighting, copying, and exporting controls are locked down to ag-grid-enterprise. Example of what I mean here: https://plnkr.co/edit/lM3OtCQxpJdapHQt?preview

I did a little bit of digging on this and found these options (https://www.ag-grid.com/angular-data-grid/cell-text-selection/) which do work.
However, they really only work well for copying one cell at a time. Selecting and copying in to a spreadsheet was ugly.

So I found a couple more options:
1. Setting `editable: true` on the columns allows double-clicking to highlight the whole cell, and then I can copy paste individual cells fine.
2. Using the `gridApi`, you can fetch selected rows and headers. I've added some buttons to copy that data to the clipboard.

This should be considered a draft or suggestion. I've never worked with React before and I feel this could be implemented better.
For one, I think the controls I added would probably look better in the top left of the table, rather than underneath it.
And two, the settings could be tied in with React's state management, rather than `getElementById` etc.

I started trying to implement these controls more properly in TableControls.tsx, but realized pretty quickly that I don't know React enough to know how to call the gridApi from there.
I didn't want to sink too much time learning the proper way of doing things without seeing if this sort of feature was something you might want.

Please let me know what you think and I'd be happy to brush this up.

___

Some other ideas I have:
1. Bind keyboard shortcuts like Ctrl+A and Ctrl+C.
2. A setting to copy *NULL* values as either "NULL" or "".
3. A setting to toggle pagination on and off.